### PR TITLE
add a "weak" feature to turn these symbols into weak symbols

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ memmove, memset and memcmp. This is designed for use in freestanding
 environments where another libc does not exist, since rustc may
 implicitly insert calls to such functions.
 """
+
+[features]
+weak = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,11 @@
 // LLVM to optimize these function calls to themselves!
 #![no_builtins]
 
-#![cfg_attr(all(feature = "weak", not(windows), not(osx)), feature(linkage))]
+// NOTE `linkage = weak` doesn't work for Windows (COFF) or MacOS (MachO). It seems it only works
+// for ELF objects.
+#![cfg_attr(all(feature = "weak", not(windows), not(target_os = "macos")), feature(linkage))]
 
-#[cfg_attr(all(feature = "weak", not(windows), not(osx)), linkage = "weak")]
+#[cfg_attr(all(feature = "weak", not(windows), not(target_os = "macos")), linkage = "weak")]
 #[no_mangle]
 pub unsafe extern fn memcpy(dest: *mut u8, src: *const u8,
                             n: usize) -> *mut u8 {
@@ -40,7 +42,7 @@ pub unsafe extern fn memcpy(dest: *mut u8, src: *const u8,
     return dest;
 }
 
-#[cfg_attr(all(feature = "weak", not(windows), not(osx)), linkage = "weak")]
+#[cfg_attr(all(feature = "weak", not(windows), not(target_os = "macos")), linkage = "weak")]
 #[no_mangle]
 pub unsafe extern fn memmove(dest: *mut u8, src: *const u8,
                              n: usize) -> *mut u8 {
@@ -60,7 +62,7 @@ pub unsafe extern fn memmove(dest: *mut u8, src: *const u8,
     return dest;
 }
 
-#[cfg_attr(all(feature = "weak", not(windows), not(osx)), linkage = "weak")]
+#[cfg_attr(all(feature = "weak", not(windows), not(target_os = "macos")), linkage = "weak")]
 #[no_mangle]
 pub unsafe extern fn memset(s: *mut u8, c: i32, n: usize) -> *mut u8 {
     let mut i = 0;
@@ -71,7 +73,7 @@ pub unsafe extern fn memset(s: *mut u8, c: i32, n: usize) -> *mut u8 {
     return s;
 }
 
-#[cfg_attr(all(feature = "weak", not(windows), not(osx)), linkage = "weak")]
+#[cfg_attr(all(feature = "weak", not(windows), not(target_os = "macos")), linkage = "weak")]
 #[no_mangle]
 pub unsafe extern fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
     let mut i = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,9 @@
 // LLVM to optimize these function calls to themselves!
 #![no_builtins]
 
+#![cfg_attr(all(feature = "weak", not(windows), not(osx)), feature(linkage))]
+
+#[cfg_attr(all(feature = "weak", not(windows), not(osx)), linkage = "weak")]
 #[no_mangle]
 pub unsafe extern fn memcpy(dest: *mut u8, src: *const u8,
                             n: usize) -> *mut u8 {
@@ -37,6 +40,7 @@ pub unsafe extern fn memcpy(dest: *mut u8, src: *const u8,
     return dest;
 }
 
+#[cfg_attr(all(feature = "weak", not(windows), not(osx)), linkage = "weak")]
 #[no_mangle]
 pub unsafe extern fn memmove(dest: *mut u8, src: *const u8,
                              n: usize) -> *mut u8 {
@@ -56,6 +60,7 @@ pub unsafe extern fn memmove(dest: *mut u8, src: *const u8,
     return dest;
 }
 
+#[cfg_attr(all(feature = "weak", not(windows), not(osx)), linkage = "weak")]
 #[no_mangle]
 pub unsafe extern fn memset(s: *mut u8, c: i32, n: usize) -> *mut u8 {
     let mut i = 0;
@@ -66,6 +71,7 @@ pub unsafe extern fn memset(s: *mut u8, c: i32, n: usize) -> *mut u8 {
     return s;
 }
 
+#[cfg_attr(all(feature = "weak", not(windows), not(osx)), linkage = "weak")]
 #[no_mangle]
 pub unsafe extern fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
     let mut i = 0;


### PR DESCRIPTION
@alexcrichton How do you feel about adding this feature? We'll like to include these symbols, in their weak version, in [rustc-builtins](https://github.com/japaric/rustc-builtins). That way, after that crate is upstreamed to rust-lang/rust, `no_std` users won't have to explicitly reach out for the rlibc crate to get these symbols; and, also, because these symbols would appear as weak symbols in rustc-builtins `std` users would continue using the optimized version provided by `libc`.

The other option is to simply copy these functions into rustc-builtins. The downside is that issues like #13 would have to be fixed in two places.

cc @shepmaster