### PR TITLE
Make it easy to use this in cross-compiled projects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,9 @@ implicitly insert calls to such functions.
 
 [features]
 weak = []
+default = []
+
+cross-compile = ["rust-libcore"]
+
+[dependencies]
+rust-libcore = {version = "*", optional = true}


### PR DESCRIPTION
This is a very useful crate for `no_std` projects. If we are cross-compiling, though, we want to induce cargo to rebuild libcore and cause this crate to use the cross-compiled libcore. By adding this optional dependency, the crate maintains its existing functionality by default. And those who want to cross-compile can simply use the `cross-compile` feature in their `Cargo.toml`.