### PR TITLE
add x86_64 assembly version of memcpy, memset and memmove

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ implicitly insert calls to such functions.
 
 [features]
 weak = []
+nightly = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,11 +92,18 @@ pub unsafe extern fn memmove(dest: *mut u8, src: *const u8,
 	let mut _k: usize;
 
     if src < dest as *const u8 { // copy from end
-		asm!(
-			"std; rep movsq; movq $4, %rcx; andq $$7, %rcx; rep movsb; cld"
-			: "={rcx}"(_i), "={rdx}"(_j), "={rsi}"(_k)
-			: "0"(n/8), "r"(n), "1"(dest.offset(n as isize)), "2"(src.offset(n as isize)) : "memory","cc");
-    } else { // copy from beginning
+		if n >= 8 {
+			asm!(
+				"std; rep movsq; movq $4, %rcx; andq $$7, %rcx; rep movsb; cld"
+				: "={rcx}"(_i), "={rdx}"(_j), "={rsi}"(_k)
+				: "0"(n/8), "r"(n), "1"(dest.offset((n-8) as isize)), "2"(src.offset((n-8) as isize)) : "memory","cc");
+		} else if n > 0 {
+			asm!(
+				"std; rep movsb; cld"
+				: "={rcx}"(_i), "={rdx}"(_j), "={rsi}"(_k)
+				: "0"(n), "1"(dest.offset((n-1) as isize)), "2"(src.offset((n-1) as isize)) : "memory","cc");
+		}
+    } else if n > 0 { // copy from beginning
 		asm!(
 			"cld; rep movsq; movq $4, %rcx; andq $$7, %rcx; rep movsb"
 			: "={rcx}"(_i), "={rdx}"(_j), "={rsi}"(_k)


### PR DESCRIPTION
I do some kernel experiments with Rust (https://github.com/RWTH-OS/eduOS-rs). Normally, I use my own assembly versions of memcpy & Co, which are fast and usable in kernel space. I integrate my Rust port in rlibc. Maybe it is interesting for someone. You can enable these versions by adding following section in your Cargo.toml file.

[dependencies.rlibc]
features = ["nightly"]